### PR TITLE
Drop unused dependency on integer-gmp.

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -98,14 +98,6 @@ library
 
   ghc-options: -Wall
 
-  cpp-options: -DINTEGER_GMP
-
-  if impl(ghc >= 6.11)
-    build-depends: integer-gmp >= 0.2
-
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
-    build-depends: integer >= 0.1 && < 0.2
-
 test-suite tests
   type: exitcode-stdio-1.0
   hs-source-dirs: tests


### PR DESCRIPTION
Hi,

thanks for this library, and all your other great libraries!

While trying to modify this library to compile with integer-simple, I realised that the dependency on integer-gmp seems to be superfluous. I guess it was used in the distant past, before switching to git, but I couldn't find a place in the code where it's used any more. I'd suggest removing the dependency.

Best,
Philipp