### PR TITLE
Windows: fix C depenencies for Windows

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -70,8 +70,14 @@ library
     double-conversion/src/fast-dtoa.cc
     double-conversion/src/fixed-dtoa.cc
     double-conversion/src/strtod.cc
-
-  extra-libraries: stdc++
+    
+  if os(windows)
+    if arch(x86_64)
+      extra-libraries: stdc++-6 gcc_s_seh-1
+    else
+      extra-libraries: stdc++-6 gcc_s_dw2-1
+  else
+    extra-libraries: stdc++
 
   include-dirs:
     double-conversion/src


### PR DESCRIPTION
Library is mentioned in GHC bug https://ghc.haskell.org/trac/ghc/ticket/5289#comment:45
These changes are required to the cabal file to make it work with GHC on Windows.

GHC 8.x will be able to use this on Windows.
