### PR TITLE
Use `c++` library on Darwin, not `stdc++`

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -71,7 +71,10 @@ library
     double-conversion/src/fixed-dtoa.cc
     double-conversion/src/strtod.cc
 
-  extra-libraries: stdc++
+  if os(darwin)
+    extra-libraries: c++
+  else
+    extra-libraries: stdc++
 
   include-dirs:
     double-conversion/src


### PR DESCRIPTION
Recent versions of OS X name their C++ standard library `c++` instead of `stdc++`. This results in the following error attempting to build `double-conversion` on Darwin:

```
    Configuring double-conversion-2.0.1.1...
    Preprocessing library double-conversion-2.0.1.1...
    [1 of 3] Compiling Data.Double.Conversion.FFI ( Data/Double/Conversion/FFI.hs, .stack-work/dist/x86_64-osx/Cabal-1.22.5.0/build/Data/Double/Conversion/FFI.o )
    [2 of 3] Compiling Data.Double.Conversion.Text ( Data/Double/Conversion/Text.hs, .stack-work/dist/x86_64-osx/Cabal-1.22.5.0/build/Data/Double/Conversion/Text.o )
    [3 of 3] Compiling Data.Double.Conversion.ByteString ( Data/Double/Conversion/ByteString.hs, .stack-work/dist/x86_64-osx/Cabal-1.22.5.0/build/Data/Double/Conversion/ByteString.o )
    ld: library not found for -lstdc++
    clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
```

This patch fixes the issue and results in a clean build for me on OS X 10.11.

It would be preferable to switch on the OS version number or the presence of the `libstdc++` library, but I don't think that's possible with Cabal `build-type: Simple`.
