### PR TITLE
Import data constructors from Foreign.C.Types

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -3,7 +3,7 @@
 import Criterion.Main
 import qualified Data.Double.Conversion.ByteString as B
 import qualified Data.Double.Conversion.Text as T
-import Foreign.C.Types (CInt, CDouble)
+import Foreign.C.Types (CInt(CInt), CDouble(CDouble))
 import qualified Data.Text as T
 import qualified Text.Show.ByteString as BS
 


### PR DESCRIPTION
Trying to build benchmarks under GHC 7.10.3 gives me this error:

```
    .../double-conversion/benchmarks/Benchmarks.hs:36:1:
        Unacceptable argument type in foreign declaration:
          ‘CDouble’ cannot be marshalled in a foreign call
            because its data construtor is not in scope
            Possible fix: import the data constructor to bring it into scope
        When checking declaration:
          foreign import ccall unsafe "static sprintf_exact" sprintf_exact
            :: CDouble -> ()
```

The attached pull request imports the data constructors from `Foreign.C.Types` and fixes the build for me. Thanks!
