### PR TITLE
Explicitly link with libm to support using ld.gold

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -80,7 +80,7 @@ library
     if os(darwin)
       extra-libraries: c++
     else
-      extra-libraries: stdc++
+      extra-libraries: stdc++ m
 
   include-dirs:
     double-conversion/src


### PR DESCRIPTION
This enables the package to be linked using `ld.gold`. Linking using the normal `ld` also still works.